### PR TITLE
add recovery_manager(undo/redo) without checkpoint

### DIFF
--- a/include/storage/KVStore.h
+++ b/include/storage/KVStore.h
@@ -7,7 +7,7 @@
 #include "SkipList.h"
 #include "DiskStorage.h"
 #include "Transaction.h"
-#include "log_manager.h"
+// #include "log_manager.h"
  
 class KVStore{
  public:
@@ -21,10 +21,12 @@ class KVStore{
     bool del(uint64_t key, Transaction *txn);
 
     // put(key, value)
+    void put(const std::string & key, const std::string &value);
     void put(const std::string & key, const std::string &value, Transaction *txn);
     // value = get(key)
     std::string get(const std::string & key, Transaction *txn);
     // del(key)
+    bool del(const std::string & key);
     bool del(const std::string & key, Transaction *txn);
     
     // clear memtable and disk
@@ -34,7 +36,7 @@ class KVStore{
  private:
     SkipList memtable_;
     DiskStorage diskstorage_;
-    LogManager* log_manager_;
+   //  LogManager* log_manager_;
 };
 
 #endif

--- a/include/storage/LogStorage.h
+++ b/include/storage/LogStorage.h
@@ -56,10 +56,8 @@ public:
         return rc == 0 ? static_cast<int> (stat_buf.st_size) : -1;
     }
 
-    bool ReadLog(char *log_data, int size, int offset) {
+    bool ReadLog(char *log_data, int size, size_t offset) {
 
-        // this is stupid. we should cache the log size then read it till end
-        // since log file won't change while performing recovery protocol.
         if (offset >= GetFileSize(log_name_)) {
             return false;
         }

--- a/src/recovery/log_manager.h
+++ b/src/recovery/log_manager.h
@@ -46,10 +46,11 @@ public:
 
     void SwapBuffer();
 
-    inline lsn_t GetNextLsn() { return next_lsn_; }
-    inline lsn_t GetFlushLsn() { return flush_lsn_; }
-    inline char * GetLogBuffer() { return log_buffer_; }
-    inline lsn_t GetPersistentLsn() { return persistent_lsn_; }
+    inline lsn_t GetNextLsn() const { return next_lsn_; }
+    inline void SetNextLsn(lsn_t next_lsn) {next_lsn_ = next_lsn;}
+    inline lsn_t GetFlushLsn() const { return flush_lsn_; }
+    inline char * GetLogBuffer() const { return log_buffer_; }
+    inline lsn_t GetPersistentLsn() const { return persistent_lsn_; }
 
 private:
 

--- a/src/recovery/log_record.h
+++ b/src/recovery/log_record.h
@@ -66,6 +66,8 @@ public:
     inline const char* GetValue()  { return value_; }
     // inline const char* GetOldValue()  { return old_value_; }
 
+    // LogRecord DeserializeFrom(const char* storage);
+
 private:
     int32_t size_{0};
     lsn_t lsn_{INVALID_LSN};
@@ -84,3 +86,53 @@ private:
     // const char* old_value_;
 
 };
+
+LogRecord DeserializeFrom(const char* storage){
+    int32_t size = *reinterpret_cast<const int32_t *>(storage);
+    storage += sizeof(int32_t);
+    lsn_t lsn = *reinterpret_cast<const lsn_t *>(storage);
+    storage += sizeof(lsn_t);
+    txn_id_t txn_id = *reinterpret_cast<const txn_id_t *>(storage);
+    storage += sizeof(txn_id_t);
+    lsn_t prev_lsn = *reinterpret_cast<const lsn_t *>(storage);
+    storage += sizeof(lsn_t);
+    LogRecordType type = *reinterpret_cast<const LogRecordType *>(storage);
+    storage += sizeof(LogRecordType);
+
+    LogRecord res;
+    assert(type != LogRecordType::INVALID);
+    // then deserialize data based on type
+    // WARNING!!! don't forget to set lsn since constructor won't provide parameter to initialize lsn
+    switch (type) {
+    case LogRecordType::COMMIT:
+    case LogRecordType::ABORT:
+    case LogRecordType::BEGIN: {
+        res = LogRecord(txn_id, prev_lsn, type);
+        break;
+    }
+    case LogRecordType::INSERT:
+    case LogRecordType::DELETE: {
+        uint32_t key_size = *reinterpret_cast<const uint32_t *>(storage);
+        storage += sizeof(uint32_t);
+        char* key = new char[key_size];
+        memcpy(key, storage, key_size);
+        storage += key_size;
+
+        uint32_t value_size = *reinterpret_cast<const uint32_t *>(storage);
+        storage += sizeof(uint32_t);
+        char* value = new char[value_size];
+        memcpy(value, storage, value_size);
+        storage += value_size;
+
+        res = LogRecord(txn_id, prev_lsn, type , key_size, key, value_size, value);
+        break;
+    }
+    default:
+        std::cerr << "Invalid Log Type";
+    }
+
+    res.SetLsn(lsn);
+    assert(size == res.GetSize());
+    return res;
+}
+    

--- a/src/recovery/recovery_manager.cpp
+++ b/src/recovery/recovery_manager.cpp
@@ -1,0 +1,146 @@
+#include "recovery_manager.h"
+#include <set>
+
+void RecoveryManager::ARIES() {
+    Scan();
+    Redo();
+    Undo();
+}
+
+void RecoveryManager::Scan() {
+    // only perform scan(analyse) phase when we need to recover from checkpoint
+}
+
+void RecoveryManager::Redo() {
+    // currently, we only support recovery from empty database, so there is no dirty page
+    int offset = 0;
+    int max_lsn = INVALID_LSN;
+    while (log_storage_->ReadLog(buffer_, LOG_BUFFER_SIZE, offset)) {
+        int inner_offset = 0;
+        while (true) {
+            // first probe the size
+            uint32_t size = *reinterpret_cast<const uint32_t *>(buffer_ + inner_offset);
+            // size = 0 means there is no more log records
+            // we shall stop when buffer is empty or there is no more log records
+            if (size == 0 || size + inner_offset > LOG_BUFFER_SIZE) {
+                break;
+            }
+            auto log = DeserializeFrom(buffer_ + inner_offset);
+            // update max lsn
+            max_lsn = std::max(max_lsn, log.GetLsn());
+            // remember the necessary information to retrieve log based on lsn
+            lsn_mapping_[log.GetLsn()] = std::make_pair(offset + inner_offset, size);
+            // redo the log if necessary
+            RedoLog(log);
+
+            inner_offset += size;
+        }
+        offset += inner_offset;
+    }
+    log_manager_->SetNextLsn(max_lsn + 1);
+}
+
+void RecoveryManager::RedoLog(LogRecord &log_record) {
+    // record last lsn
+    active_txn_[log_record.GetTxnId()] = log_record.GetLsn();
+
+    switch (log_record.GetLogRecordType()) {
+    case LogRecordType::COMMIT:
+    case LogRecordType::ABORT:
+        active_txn_.erase(log_record.GetTxnId());
+        break;
+    case LogRecordType::BEGIN:
+        active_txn_[log_record.GetTxnId()] = log_record.GetLsn();
+        break;
+    case LogRecordType::INSERT: {
+        kv_->put(std::string(log_record.GetKey(), log_record.GetKeySize()),
+            std::string(log_record.GetValue(), log_record.GetValueSize()));
+        break;
+    }
+    case LogRecordType::DELETE: {
+        kv_->del(std::string(log_record.GetKey(), log_record.GetKeySize()));
+        break;
+    }
+    case LogRecordType::CREATE_TABLE: 
+    case LogRecordType::DROP_TABLE:
+    case LogRecordType::PREPARED:{
+        // TODO
+        // do nothing now
+        break;
+    }
+    default:
+        std::cerr <<  "Invalid Log Type";
+    }
+}
+
+void RecoveryManager::Undo() {
+    // abort all the active transactions
+    // at every step in undo phase, we need to execute the log record with max lsn in undo-list
+    std::set<lsn_t> next_lsn;
+    for (auto &[key, lsn]: active_txn_) {
+        next_lsn.insert(lsn);
+    }
+
+    while (!next_lsn.empty()) {
+        auto lsn = *next_lsn.rbegin();
+        // first fetch the offset and size
+        auto [offset, size] = lsn_mapping_[lsn];
+        log_storage_->ReadLog(buffer_, size, offset);
+        // deserialize the log
+        auto log = DeserializeFrom(buffer_);
+        // undo log
+        UndoLog(log);
+        // erase current lsn and insert the previous lsn
+        next_lsn.erase(lsn);
+        if (log.GetPrevLsn() != INVALID_LSN) {
+            next_lsn.insert(log.GetPrevLsn());
+        }
+    }
+    // after redo phase is done, write abort record
+    for (auto &[txn_id, lsn]: active_txn_) {
+        auto log = LogRecord(txn_id, lsn, LogRecordType::ABORT);
+        log_manager_->AppendLogRecord(log);
+    }
+}
+
+void RecoveryManager::UndoLog(LogRecord &log_record) {
+    switch (log_record.GetLogRecordType()) {
+    case LogRecordType::BEGIN:
+    case LogRecordType::PREPARED:
+        // do nothing
+        break;
+    case LogRecordType::INSERT: {
+        // 这里调用Kvstore不传入txn事务, 因为在恢复过程中没有维护事务管理器, 通过active_txn_来跟踪
+        // 每个事务最后的lsn, 写入存储层后, 在本函数中通过active_txn_维护写入的日志信息
+        kv_->del(std::string(log_record.GetKey(),log_record.GetKeySize()));
+        // undo操作也需要写redo log
+        auto log = LogRecord(log_record.GetTxnId(), 
+                             active_txn_[log_record.GetTxnId()],  
+                             LogRecordType::DELETE, 
+                             log_record.GetKeySize(), log_record.GetKey(),
+                             log_record.GetValueSize(), log_record.GetValue());
+        log_manager_->AppendLogRecord(log);
+
+        // update last lsn
+        active_txn_[log_record.GetTxnId()] = log.GetLsn();
+        break;
+    }
+    case LogRecordType::DELETE: {
+        kv_->put(std::string(log_record.GetKey(),log_record.GetKeySize()),
+                    std::string(log_record.GetKey(),log_record.GetKeySize()));
+
+        auto log = LogRecord(log_record.GetTxnId(), 
+                             active_txn_[log_record.GetTxnId()],  
+                             LogRecordType::INSERT, 
+                             log_record.GetKeySize(), log_record.GetKey(),
+                             log_record.GetValueSize(), log_record.GetValue());
+        log_manager_->AppendLogRecord(log);
+        // update lsn
+        active_txn_[log_record.GetTxnId()] = log.GetLsn();
+        break;
+    }
+    default:
+        std::cerr <<  "Invalid Log Type";
+    }
+
+}

--- a/src/recovery/recovery_manager.h
+++ b/src/recovery/recovery_manager.h
@@ -1,0 +1,50 @@
+#ifndef RECOVERY_MANAGER_H
+#define RECOVERY_MANAGER_H
+
+#include "log_manager.h"
+#include "log_record.h"
+#include "KVStore.h"
+
+#include <unordered_map>
+
+
+class RecoveryManager {
+public:
+    RecoveryManager(LogStorage *log_storage, LogManager *log_manager)
+        : log_storage_(log_storage), log_manager_(log_manager) {
+        buffer_ = new char[LOG_BUFFER_SIZE];
+    }
+
+    ~RecoveryManager() {
+        delete[] buffer_;
+    }
+    
+    /**
+     * @brief 
+     * Perform the recovery procedure
+     */
+    void ARIES();
+
+private:
+    // helper function
+    void Scan();
+    void Redo();
+    void Undo();
+    void RedoLog(LogRecord &log_record);
+    void UndoLog(LogRecord &log_record);
+
+    // buffer used to store log data
+    char *buffer_{nullptr};
+
+    LogStorage *log_storage_;
+    KVStore *kv_;
+    LogManager *log_manager_;
+    // we need to keep track of what txn we need to undo
+    // txn -> last lsn
+    std::unordered_map<txn_id_t, lsn_t> active_txn_;
+    // remember the offset of a log record
+    // lsn -> (offset in disk, size of log)
+    std::unordered_map<lsn_t, std::pair<int, int>> lsn_mapping_;
+};
+
+#endif

--- a/src/storage/KVStore.cpp
+++ b/src/storage/KVStore.cpp
@@ -12,6 +12,17 @@ KVStore::~KVStore() {
 }
 
 // put(key, value)
+void KVStore::put(const std::string & key, const std::string &value){
+
+    // TODO
+    // memtable_.put(key, value);
+    // if(memtable_.space() > Option::SSTABLE_SPACE){
+    //     diskstorage_.add(memtable_);
+    //     memtable_.clear();
+    // }
+}
+
+// put(key, value)
 void KVStore::put(const std::string & key, const std::string &value, Transaction *txn){
     if(enable_logging){
         //写Put日志


### PR DESCRIPTION
添加了redo/undo恢复过程，但没有涉及到检查点操作，有了Redo可以尝试和raft接入服用Redo函数

Kvstorage需要有两套接口，一个为传入事务指针，一个不传入事务指针，因为在恢复过程中不在事务管理器中维护事务。